### PR TITLE
Fix some errors

### DIFF
--- a/spec/basic_types/index.html
+++ b/spec/basic_types/index.html
@@ -253,7 +253,7 @@ or <code>integer</code> types.</p>
    "maximum": 150
  }</code></pre></p>
 <p>This document validates against any number between <code>0</code> and <code>150</code>.
-By default the ranges are inclusive: <code>"minimum": n</code> imposes the restriction that numbers need to be <em>greater than or equal to</em> <code>n</code>, and <code>"minimum": m</code> imposes that numbers need to be <em>less than or equal to</em> <code>m</code>. This means that both <code>0</code> and <code>150</code> satisfy the schema above. We can switch the ranges to be exclusive by using the <code>"exclusiveMinimum"</code> and <code>"exclusiveMaximum"</code> keywords. </p>
+By default the ranges are inclusive: <code>"minimum": n</code> imposes the restriction that numbers need to be <em>greater than or equal to</em> <code>n</code>, and <code>"maximum": m</code> imposes that numbers need to be <em>less than or equal to</em> <code>m</code>. This means that both <code>0</code> and <code>150</code> satisfy the schema above. We can switch the ranges to be exclusive by using the <code>"exclusiveMinimum"</code> and <code>"exclusiveMaximum"</code> keywords. </p>
 <p>For example, the following schema validates against <code>0</code>, but not against <code>150</code>:</p>
 <p><pre><code> {
    "type":"integer", 

--- a/spec/generic_keywords/index.html
+++ b/spec/generic_keywords/index.html
@@ -309,7 +309,7 @@
     "required": ["first_name", "last_name", "age", "club"]
 }</code></pre>
 
-<p>First, the <code>"$schema"</code> keyword specifies that the current schema follows the specification of the version 3 of JSON Schema. We can provide different versions deppending of our requirements. The <code>"title"</code> keyword is useful to give a name to the schema. Similarly, the <code>"description"</code> keyword is useful to give a short description of what kind of documents the schema accepts. Finally the <code>"default"</code> keyword can be used to specify a default value for the document if a hipothetical validator reads a missing value as input.</p></div>
+<p>First, the <code>"$schema"</code> keyword specifies that the current schema follows the specification of the version 4 of JSON Schema. We can provide different versions deppending of our requirements. The <code>"title"</code> keyword is useful to give a name to the schema. Similarly, the <code>"description"</code> keyword is useful to give a short description of what kind of documents the schema accepts. Finally the <code>"default"</code> keyword can be used to specify a default value for the document if a hipothetical validator reads a missing value as input.</p></div>
         </div>
 
         <footer class="col-md-12">


### PR DESCRIPTION
At basic types, minimum was written when describing the maximum behaviour. 
From the look of the link in generic keywords, the jsonschema version seems to be of version 4 not 3.